### PR TITLE
updating flood to use cKDTree instead of a naive implementation

### DIFF
--- a/pyroms/pyroms/remapping/flood.py
+++ b/pyroms/pyroms/remapping/flood.py
@@ -5,9 +5,124 @@ from .. import _remapping
 
 import pyroms
 from pyroms import _remapping
+from scipy.spatial import cKDTree
 
 
-def flood(varz, grdz, Cpos='rho', irange=None, jrange=None, \
+
+def flood(varz, Cgrd, Cpos='t', irange=None, jrange=None, \
+          spval=-9.99e+33, dmax=0, cdepth=0, kk=0):
+    """
+    var = flood(var, Cgrd)
+
+    optional switch:
+      - Cpos='t', 'u', 'v'           specify the grid position where
+                                     the variable resides
+      - irange                       specify grid sub-sample for i direction
+      - jrange                       specify grid sub-sample for j direction
+      - spval=1e35                   define spval value
+      - dmax=0                       if dmax>0, maximum horizontal
+                                     flooding distance
+      - cdepth=0                     critical depth for flooding
+                                     if depth<cdepth => no flooding
+      - kk
+
+    Flood varz on Cgrd
+    """
+
+    varz = varz.copy()
+    varz = np.array(varz)
+
+    assert len(varz.shape) == 3, 'var must be 3D'
+
+    # replace spval by nan
+    idx = np.where(abs((varz-spval)/spval)<=1e-5)
+    varz[idx] = np.nan
+
+    x = Cgrd.lon_t
+    y = Cgrd.lat_t
+    h = Cgrd.h
+    if Cpos is 't':
+        mask = Cgrd.mask_t[0,:,:]
+    elif Cpos is 'u':
+        mask = Cgrd.mask_u[0,:,:]
+    elif Cpos is 'v':
+        mask = Cgrd.mask_v[0,:,:]
+
+    nlev, Mm, Lm = varz.shape
+
+    if irange is None:
+        irange = (0,Lm)
+    else:
+        assert varz.shape[2] == irange[1]-irange[0], \
+               'var shape and irange must agreed'
+
+    if jrange is None:
+        jrange = (0,Mm)
+    else:
+        assert varz.shape[1] == jrange[1]-jrange[0], \
+               'var shape and jrange must agreed'
+
+    x = x[jrange[0]:jrange[1], irange[0]:irange[1]]
+    y = y[jrange[0]:jrange[1], irange[0]:irange[1]]
+    h = h[jrange[0]:jrange[1], irange[0]:irange[1]]
+    mask = mask[jrange[0]:jrange[1], irange[0]:irange[1]]
+
+    # Finding nearest values in horizontal
+    # critical deph => no change if depth is less than specified value
+    cdepth = abs(cdepth)
+    if cdepth != 0:
+        idx = np.where(h >= cdepth)
+        msk = np.zeros(mask.shape)
+        msk[idx] = 1
+    else:
+        msk = mask.copy()
+    for k in range(nlev-1,0,-1):
+        c1 = np.array(msk, dtype=bool)   # land mask
+        c2 = np.isnan(varz[k,:,:]) == 1  # water values
+        if kk == 0:
+            c3 = np.ones(mask.shape).astype(bool)
+        else:
+            c3 = np.isnan(varz[min(k-kk,0),:,:]) == 0
+        c = c1 & c2 & c3
+
+        idxnan = np.where(c == True)
+        idx = np.where(c2 == False)
+        if list(idx[0]):
+
+            wet = np.zeros((len(idx[0]),2)).astype(int)
+            dry = np.zeros((len(idxnan[0]),2)).astype(int)
+            wet[:,0] = idx[0].astype(int)
+            wet[:,1] = idx[1].astype(int)
+            dry[:,0] = idxnan[0].astype(int)
+            dry[:,1] = idxnan[1].astype(int)
+            xwet = x[wet[:,0], wet[:,1]]
+            ywet = y[wet[:,0], wet[:,1]]
+            xdry = x[dry[:,0], dry[:,1]]
+            ydry = y[dry[:,0], dry[:,1]]
+
+            xy = np.array([xdry,ydry])
+            tree = cKDTree(np.c_[xwet, ywet])
+            _, ii = tree.query(xy.T, k=1)
+            varz[k,dry[:,0], dry[:,1]] = varz[k,wet[ii,0],wet[ii,1]]
+
+
+
+            # varz[k,:] = _remapping.flood(varz[k,:], wet, dry, x, y, dmax)
+
+    # drop the deepest values down
+    idx = np.where(np.isnan(varz) == 1)
+    varz[idx] = spval
+    bottom = pyroms.utility.get_bottom(varz[::-1,:,:], mask, spval=spval)
+    bottom = (nlev-1) - bottom
+    for i in range(Lm):
+        for j in range(Mm):
+            if mask[j,i] == 1:
+                varz[int(bottom[j,i]):,j,i] = varz[int(bottom[j,i]),j,i]
+
+    return varz
+
+
+def flood_original(varz, grdz, Cpos='rho', irange=None, jrange=None, \
           spval=1e37, dmax=0, cdepth=0, kk=0):
     """
     var = flood(var, grdz)


### PR DESCRIPTION
This [issue](https://github.com/lhico/pyroms_tools/issues/18) was raised in our pyroms_tools. The naive implementation of the method flood in [remapping.f](https://github.com/lhico/pyroms/blob/python3/pyroms/pyroms/src/remapping.f) has O(N) complexity  . This algorithm is based on a nearest neighbor search algorithm, that extrapolates the values to the entire grid.

We updated the method to use a cKDTree from `scipy.spatial`, which has O(log[n]) complexity, which significantly sped up the computation.